### PR TITLE
Added require to run supervisor program

### DIFF
--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -28,7 +28,7 @@ define supervisor::program (
     provider => base,
     start    => "supervisorctl start ${name}:*",
     status   => "supervisorctl status ${name}:* | grep -cv 'RUNNING' | grep '^0$'",
-    require  => [File["/etc/supervisor/conf.d/${name}.conf"], , Exec['supervisor-update']]
+    require  => [File["/etc/supervisor/conf.d/${name}.conf"], Exec['supervisor-update']]
   }
 
 }

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -28,7 +28,7 @@ define supervisor::program (
     provider => base,
     start    => "supervisorctl start ${name}:*",
     status   => "supervisorctl status ${name}:* | grep -cv 'RUNNING' | grep '^0$'",
-    require  => File["/etc/supervisor/conf.d/${name}.conf"]
+    require  => [File["/etc/supervisor/conf.d/${name}.conf"], , Exec['supervisor-update']]
   }
 
 }


### PR DESCRIPTION
Sometimes puppet write error `Error: Could not start Service[supervisor-xxx]: Execution of 'supervisorctl start xxx:*' returned 2: dev: ERROR (no such group)`  because the supervisor daemon is not reloaded.